### PR TITLE
perf: add sharded/batch runners and dense model helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ models/*.png
 !models/best_model_image_rotation_0.996_2024-04-14-22-59-55.pth
 !models/best_model_existence_0.998_2024-04-16-23-44-48.pth
 !models/best_model_fen_0.943_2024-04-19-09-31-24.pth
+.venv/

--- a/bench/e2e_smoke.py
+++ b/bench/e2e_smoke.py
@@ -1,0 +1,53 @@
+import numpy as np
+import torch
+
+from speedkit.io import normalize_inplace_bgr_to_rgb01
+from speedkit.tiles import crop_tiles_vectorized, tiles_to_batch
+from speedkit.torch_fast import batch_tiles_mps
+from speedkit.fen import fen_from_grid
+
+# --- Dummy invoerbord: willekeurige pixels (we testen alleen de pijplijn, niet echte herkenning)
+# Maak een 512x512 "BGR" beeld zoals cv2.imread zou doen.
+board_bgr = (np.random.rand(512, 512, 3) * 255).astype(np.uint8)
+
+# 1) Normaliseren (BGR -> RGB [0,1] -> gestandaardiseerd)
+board_rgb = normalize_inplace_bgr_to_rgb01(board_bgr)
+
+# 2) 64 tiles snijden (vectorized) en NCHW batch maken
+tiles = crop_tiles_vectorized(board_rgb, grid=8)               # (8,8,64,64,3)
+batch = tiles_to_batch(tiles).astype(np.float32)               # (64,3,64,64)
+
+# 3) Dummy model dat een bekende stelling "faket", zodat FEN voorspelbaar is.
+#    We willen als output: "rnbqkbnr/pppppppp/8/8/8/8/8/8"
+#    Mapping die we in speedkit.fen gebruikten:
+#    0=empty, 1..6 = P N B R Q K, 7..12 = p n b r q k
+row0_ids = np.array([10, 8, 9, 11, 12, 9, 8, 10], dtype=np.int64)  # r n b q k b n r
+row1_ids = np.full((8,), 7, dtype=np.int64)                       # p p p p p p p p
+rest    = np.zeros((6, 8), dtype=np.int64)                        # empties
+grid_ids = np.vstack([row0_ids, row1_ids, rest])                  # (8,8)
+
+# We maken een model dat de logits zo teruggeeft dat argmax == grid_ids.flatten()
+class DummyModel(torch.nn.Module):
+    def __init__(self, labels_8x8):
+        super().__init__()
+        self.labels = torch.from_numpy(labels_8x8.reshape(-1))  # (64,)
+        self.n_cls = 13
+    def forward(self, x):
+        B = x.shape[0]                # verwacht 64
+        assert B == 64, f"Expected 64 tiles, got {B}"
+        logits = torch.zeros(B, self.n_cls, device=x.device)
+        logits += -10.0               # lage score overal
+        logits[torch.arange(B), self.labels.to(x.device)] = 10.0  # hoge score op juiste klasse
+        return logits
+
+device = "mps" if torch.backends.mps.is_available() else "cpu"
+model = DummyModel(grid_ids).to(device)
+
+# 4) Eén gebatchte forward (AMP + channels_last via helper)
+logits = batch_tiles_mps(model, batch, device=device, use_amp=True)  # (64,13)
+
+# 5) Labels -> (8,8) -> FEN
+pred = logits.argmax(dim=-1).view(8,8).cpu().numpy()
+fen = fen_from_grid(pred)
+print("Pred FEN:", fen)
+# Verwacht: rnbqkbnr/pppppppp/8/8/8/8/8/8

--- a/bench/fastpath_wrapper.py
+++ b/bench/fastpath_wrapper.py
@@ -1,0 +1,86 @@
+import argparse, time, numpy as np, torch
+from pathlib import Path
+
+from speedkit.io import imread_fast, normalize_inplace_bgr_to_rgb01
+from speedkit.tiles import crop_tiles_vectorized, tiles_to_batch
+from speedkit.torch_fast import batch_tiles_mps
+from speedkit.fen import fen_from_grid
+
+# --- DummyModel die een vaste stelling voorspelt: "rnbqkbnr/pppppppp/8/8/8/8/8/8"
+ROW0 = np.array([10, 8, 9, 11, 12, 9, 8, 10], dtype=np.int64)  # r n b q k b n r
+ROW1 = np.full((8,), 7, dtype=np.int64)                        # p p p p p p p p
+REST = np.zeros((6, 8), dtype=np.int64)
+GRID_IDS = np.vstack([ROW0, ROW1, REST])                       # (8,8)
+
+class DummyModel(torch.nn.Module):
+    def __init__(self, labels_8x8):
+        super().__init__()
+        self.labels = torch.from_numpy(labels_8x8.reshape(-1))  # (64,)
+        self.n_cls = 13
+    def forward(self, x):
+        B = x.shape[0]
+        assert B == 64, f"Expected 64 tiles, got {B}"
+        logits = torch.zeros(B, self.n_cls, device=x.device)
+        logits += -10.0
+        logits[torch.arange(B), self.labels.to(x.device)] = 10.0
+        return logits
+
+def process_board_bgr(img_bgr, model, device="mps", use_amp=True):
+    board_rgb = normalize_inplace_bgr_to_rgb01(img_bgr)            # (H,W,3) float32 RGB normed
+    tiles = crop_tiles_vectorized(board_rgb, grid=8)                # (8,8,64,64,3)
+    batch = tiles_to_batch(tiles).astype(np.float32)                # (64,3,64,64)
+    logits = batch_tiles_mps(model, batch, device=device, use_amp=use_amp)  # (64,13)
+    labels = logits.argmax(dim=-1).view(8,8).cpu().numpy()
+    fen = fen_from_grid(labels)
+    return fen
+
+def main():
+    ap = argparse.ArgumentParser(description="Fastpath demo (AMP + channels_last + vectorized tiles)")
+    ap.add_argument("--input", nargs="*", help="Pad(den) naar bord-afbeeldingen (png/jpg).")
+    ap.add_argument("--dummy", type=int, default=0, help="Aantal dummy-borden genereren i.p.v. echte afbeeldingen.")
+    ap.add_argument("--device", default="mps", choices=["mps","cpu"], help="Device voor inference.")
+    ap.add_argument("--runs", type=int, default=1, help="Aantal herhalingen voor timing.")
+    ap.add_argument("--amp", action="store_true", help="Gebruik AMP fp16 op MPS.")
+    args = ap.parse_args()
+
+    device = args.device if (args.device=="mps" and torch.backends.mps.is_available()) else "cpu"
+    model = DummyModel(GRID_IDS).to(device)
+
+    boards = []
+    if args.input:
+        for p in args.input:
+            path = Path(p)
+            if path.is_dir():
+                boards += [str(f) for f in path.glob("*.png")] + [str(f) for f in path.glob("*.jpg")] + [str(f) for f in path.glob("*.jpeg")]
+            elif path.exists():
+                boards.append(str(path))
+        if not boards:
+            raise SystemExit("Geen geldige input-afbeeldingen gevonden.")
+    elif args.dummy > 0:
+        boards = [f"DUMMY_{i}" for i in range(args.dummy)]
+    else:
+        raise SystemExit("Geef --input <pad> of --dummy N.")
+
+    fens = []
+    times = []
+    for r in range(args.runs):
+        t0 = time.perf_counter()
+        for b in boards:
+            if isinstance(b, str) and b.startswith("DUMMY_"):
+                img_bgr = (np.random.rand(512,512,3)*255).astype(np.uint8)
+            else:
+                img_bgr = imread_fast(b)
+            fen = process_board_bgr(img_bgr, model, device=device, use_amp=args.amp)
+            fens.append(fen)
+        t1 = time.perf_counter()
+        times.append((t1-t0)/len(boards))
+
+    p50 = np.median(times)*1000
+    p90 = np.percentile(times, 90)*1000
+    bps = 1.0/np.median(times)
+    print(f"Boards processed: {len(boards)}  |  runs: {args.runs}")
+    print(f"p50: {p50:.3f} ms/bord   p90: {p90:.3f} ms/bord   boards/s: {bps:.2f}")
+    print("Sample FENs (eerste 3):", fens[:3])
+
+if __name__ == "__main__":
+    main()

--- a/bench/fastpath_wrapper.py
+++ b/bench/fastpath_wrapper.py
@@ -1,86 +1,127 @@
-import argparse, time, numpy as np, torch
+# bench/fastpath_wrapper.py
+import argparse
+import time
 from pathlib import Path
+
+import numpy as np
+import cv2
+import torch
 
 from speedkit.io import imread_fast, normalize_inplace_bgr_to_rgb01
 from speedkit.tiles import crop_tiles_vectorized, tiles_to_batch
 from speedkit.torch_fast import batch_tiles_mps
 from speedkit.fen import fen_from_grid
+from speedkit.project_model_loader import (
+    load_project_model,        # tile-model loader
+    load_dense_model,          # dense-model loader (single-shot)
+    predict_board_dense,       # (1,3,512,512) -> (8,8,13) logits
+)
 
-# --- DummyModel die een vaste stelling voorspelt: "rnbqkbnr/pppppppp/8/8/8/8/8/8"
-ROW0 = np.array([10, 8, 9, 11, 12, 9, 8, 10], dtype=np.int64)  # r n b q k b n r
-ROW1 = np.full((8,), 7, dtype=np.int64)                        # p p p p p p p p
-REST = np.zeros((6, 8), dtype=np.int64)
-GRID_IDS = np.vstack([ROW0, ROW1, REST])                       # (8,8)
+def process_board_bgr(
+    img_bgr,
+    device="mps",
+    use_amp=True,
+    dense=False,
+    model=None,
+    dense_model=None,
+):
+    """
+    Verwerkt één bordafbeelding tot FEN.
 
-class DummyModel(torch.nn.Module):
-    def __init__(self, labels_8x8):
-        super().__init__()
-        self.labels = torch.from_numpy(labels_8x8.reshape(-1))  # (64,)
-        self.n_cls = 13
-    def forward(self, x):
-        B = x.shape[0]
-        assert B == 64, f"Expected 64 tiles, got {B}"
-        logits = torch.zeros(B, self.n_cls, device=x.device)
-        logits += -10.0
-        logits[torch.arange(B), self.labels.to(x.device)] = 10.0
-        return logits
+    - dense=False  → tiles-pad (snijden -> batch -> model(64,3,h,w))
+    - dense=True   → single-shot dense model op 512x512
+    """
+    if dense:
+        # 1) normaliseer (BGR->RGB [0,1] + standaardisatie)
+        rgb = normalize_inplace_bgr_to_rgb01(img_bgr)  # (H,W,3) float32
+        # 2) resize naar 512x512 (zoals get_dense_model werkt)
+        rgb512 = cv2.resize(np.ascontiguousarray(rgb), (512, 512), interpolation=cv2.INTER_AREA)
+        # 3) naar torch CHW, batch=1
+        x = torch.from_numpy(rgb512.transpose(2, 0, 1)).unsqueeze(0).contiguous()
+        # 4) dense predict → (8,8,13)
+        logits_grid = predict_board_dense(dense_model, x, device=device)   # Tensor (8,8,13)
+        labels = logits_grid.argmax(dim=-1).cpu().numpy()                  # (8,8)
+        return fen_from_grid(labels)
 
-def process_board_bgr(img_bgr, model, device="mps", use_amp=True):
-    board_rgb = normalize_inplace_bgr_to_rgb01(img_bgr)            # (H,W,3) float32 RGB normed
-    tiles = crop_tiles_vectorized(board_rgb, grid=8)                # (8,8,64,64,3)
-    batch = tiles_to_batch(tiles).astype(np.float32)                # (64,3,64,64)
-    logits = batch_tiles_mps(model, batch, device=device, use_amp=use_amp)  # (64,13)
-    labels = logits.argmax(dim=-1).view(8,8).cpu().numpy()
-    fen = fen_from_grid(labels)
-    return fen
+    # Tiles-pad (bestaande flow met batching + AMP)
+    board_rgb = normalize_inplace_bgr_to_rgb01(img_bgr)      # (H,W,3) float32
+    tiles = crop_tiles_vectorized(board_rgb, grid=8)         # (8,8,tH,tW,3)
+    batch = tiles_to_batch(tiles).astype(np.float32)         # (64,3,tH,tW)
+    logits = batch_tiles_mps(model, batch, device=device, use_amp=use_amp)  # (64, n_cls)
+    labels = logits.argmax(dim=-1).view(8, 8).cpu().numpy()
+    return fen_from_grid(labels)
+
 
 def main():
-    ap = argparse.ArgumentParser(description="Fastpath demo (AMP + channels_last + vectorized tiles)")
-    ap.add_argument("--input", nargs="*", help="Pad(den) naar bord-afbeeldingen (png/jpg).")
+    ap = argparse.ArgumentParser(description="Fastpath demo: tiles (AMP) óf dense single-shot (512x512)")
+    ap.add_argument("--input", nargs="*", help="Pad(den) naar bord-afbeeldingen of mappen (png/jpg/jpeg).")
     ap.add_argument("--dummy", type=int, default=0, help="Aantal dummy-borden genereren i.p.v. echte afbeeldingen.")
-    ap.add_argument("--device", default="mps", choices=["mps","cpu"], help="Device voor inference.")
-    ap.add_argument("--runs", type=int, default=1, help="Aantal herhalingen voor timing.")
-    ap.add_argument("--amp", action="store_true", help="Gebruik AMP fp16 op MPS.")
+    ap.add_argument("--device", default="mps", choices=["mps", "cpu"], help="Device voor inference.")
+    ap.add_argument("--runs", type=int, default=1, help="Aantal herhalingen voor timing (gemiddelde p50/p90).")
+    ap.add_argument("--amp", action="store_true", help="Gebruik AMP fp16 (alleen tiles-pad op MPS).")
+    ap.add_argument("--dense", action="store_true", help="Gebruik dense single-shot model (512x512) i.p.v. tiles.")
     args = ap.parse_args()
 
-    device = args.device if (args.device=="mps" and torch.backends.mps.is_available()) else "cpu"
-    model = DummyModel(GRID_IDS).to(device)
+    # Device kiezen
+    device = args.device if (args.device == "mps" and torch.backends.mps.is_available()) else "cpu"
 
-    boards = []
+    # Model(s) laden
+    model = None
+    dense_model = None
+    if args.dense:
+        dense_model, device = load_dense_model(device=args.device)
+    else:
+        model, device = load_project_model(device=args.device)
+
+    # Input verzamelen
+    boards_paths = []
     if args.input:
         for p in args.input:
             path = Path(p)
             if path.is_dir():
-                boards += [str(f) for f in path.glob("*.png")] + [str(f) for f in path.glob("*.jpg")] + [str(f) for f in path.glob("*.jpeg")]
+                boards_paths += [str(f) for f in path.glob("*.png")]
+                boards_paths += [str(f) for f in path.glob("*.jpg")]
+                boards_paths += [str(f) for f in path.glob("*.jpeg")]
             elif path.exists():
-                boards.append(str(path))
-        if not boards:
-            raise SystemExit("Geen geldige input-afbeeldingen gevonden.")
+                boards_paths.append(str(path))
+        if not boards_paths:
+            raise SystemExit("Geen geldige input-afbeeldingen gevonden met --input.")
     elif args.dummy > 0:
-        boards = [f"DUMMY_{i}" for i in range(args.dummy)]
+        boards_paths = [f"DUMMY_{i}" for i in range(args.dummy)]
     else:
         raise SystemExit("Geef --input <pad> of --dummy N.")
 
+    # Run
     fens = []
     times = []
     for r in range(args.runs):
         t0 = time.perf_counter()
-        for b in boards:
+        for b in boards_paths:
             if isinstance(b, str) and b.startswith("DUMMY_"):
-                img_bgr = (np.random.rand(512,512,3)*255).astype(np.uint8)
+                img_bgr = (np.random.rand(512, 512, 3) * 255).astype(np.uint8)
             else:
                 img_bgr = imread_fast(b)
-            fen = process_board_bgr(img_bgr, model, device=device, use_amp=args.amp)
+            fen = process_board_bgr(
+                img_bgr,
+                device=device,
+                use_amp=args.amp,
+                dense=args.dense,
+                model=model,
+                dense_model=dense_model,
+            )
             fens.append(fen)
         t1 = time.perf_counter()
-        times.append((t1-t0)/len(boards))
+        times.append((t1 - t0) / len(boards_paths))
 
-    p50 = np.median(times)*1000
-    p90 = np.percentile(times, 90)*1000
-    bps = 1.0/np.median(times)
-    print(f"Boards processed: {len(boards)}  |  runs: {args.runs}")
+    # Statistieken
+    p50 = float(np.median(times) * 1000.0)
+    p90 = float(np.percentile(times, 90) * 1000.0)
+    bps = 1.0 / (np.median(times) if np.median(times) > 0 else 1e-9)
+
+    print(f"Boards processed: {len(boards_paths)}  |  runs: {args.runs}")
     print(f"p50: {p50:.3f} ms/bord   p90: {p90:.3f} ms/bord   boards/s: {bps:.2f}")
     print("Sample FENs (eerste 3):", fens[:3])
+
 
 if __name__ == "__main__":
     main()

--- a/bench/pdf_batch.py
+++ b/bench/pdf_batch.py
@@ -1,0 +1,93 @@
+import argparse, time
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import numpy as np
+import cv2
+import torch
+
+try:
+    import pypdfium2 as pdfium
+except Exception:
+    pdfium = None
+
+from speedkit.io import imread_fast, normalize_inplace_bgr_to_rgb01
+from speedkit.project_model_loader import load_dense_model, predict_board_dense
+from speedkit.orient import choose_best_orientation
+
+def process_bgr(img_bgr, model, device="mps"):
+    rgb = normalize_inplace_bgr_to_rgb01(img_bgr)
+    rgb512 = cv2.resize(rgb, (512, 512), interpolation=cv2.INTER_AREA)
+    x = torch.from_numpy(rgb512.transpose(2,0,1)).unsqueeze(0).contiguous()
+    logits_grid = predict_board_dense(model, x, device=device)  # (8,8,13)
+    labels = logits_grid.argmax(dim=-1).cpu().numpy()
+    _, _, fen_rows, _ = choose_best_orientation(labels)
+    return fen_rows
+
+def load_images_from_dir(d: Path):
+    imgs = []
+    for ext in ("*.png","*.jpg","*.jpeg"):
+        imgs += list(d.glob(ext))
+    return imgs
+
+def load_pages_from_pdf(pdf_path: Path, scale=2.0):
+    if pdfium is None:
+        raise SystemExit("pypdfium2 niet geïnstalleerd. Doe: pip install pypdfium2")
+    pdf = pdfium.PdfDocument(str(pdf_path))
+    for i in range(len(pdf)):
+        page = pdf[i]
+        pil = page.render(scale=scale).to_pil()  # PIL RGB
+        img = cv2.cvtColor(np.array(pil), cv2.COLOR_RGB2BGR)
+        yield img, f"{pdf_path.name}_page_{i+1:03d}"
+
+def main():
+    ap = argparse.ArgumentParser(description="Batch diagram->FEN over map of PDF (dense model)")
+    ap.add_argument("--input", required=True, help="Pad naar map met afbeeldingen OF naar PDF")
+    ap.add_argument("--workers", type=int, default=8, help="Aantal threads voor I/O + verwerking")
+    ap.add_argument("--device", default="mps", choices=["mps","cpu"], help="Device")
+    args = ap.parse_args()
+
+    device = args.device if (args.device=="mps" and torch.backends.mps.is_available()) else "cpu"
+    model, device = load_dense_model(device=args.device)
+
+    src = Path(args.input)
+    jobs = []
+    t0 = time.perf_counter()
+
+    if src.is_file() and src.suffix.lower() == ".pdf":
+        items = list(load_pages_from_pdf(src))
+        def gen():
+            for img, name in items:
+                yield (img, name)
+        def process(item):
+            img, name = item
+            return name, process_bgr(img, model, device=device)
+        iterator = gen()
+    elif src.is_dir():
+        files = load_images_from_dir(src)
+        def gen():
+            for f in files:
+                yield (f,)
+        def process(item):
+            (f,) = item
+            img = imread_fast(str(f))
+            return f.name, process_bgr(img, model, device=device)
+        iterator = gen()
+    else:
+        raise SystemExit("Geef een bestaande map met afbeeldingen of een PDF-bestand.")
+
+    out = []
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futs = {ex.submit(process, it): it for it in iterator}
+        for fut in as_completed(futs):
+            name, fen = fut.result()
+            out.append((name, fen))
+
+    dt = time.perf_counter() - t0
+    print(f"Done: {len(out)} items in {dt:.2f}s  | avg {1000*dt/len(out):.2f} ms/item")
+    out.sort(key=lambda x: x[0])
+    for name, fen in out[:10]:
+        print(name, "→", fen)
+
+if __name__ == "__main__":
+    main()

--- a/bench/run_project_batch.py
+++ b/bench/run_project_batch.py
@@ -1,0 +1,90 @@
+import argparse, time, os
+from pathlib import Path
+
+import numpy as np
+import torch
+import cv2
+
+from speedkit.io import imread_fast, normalize_inplace_bgr_to_rgb01
+from speedkit.project_model_loader import load_dense_model, predict_board_dense
+from speedkit.orient import choose_best_orientation
+
+
+def process_board_bgr_dense(img_bgr, device, dense_model):
+    """Dense single-shot: (512x512) -> (8,8,13) -> FEN (met oriëntatie/legality)."""
+    # BGR uint8 -> RGB [0,1] float32
+    rgb = normalize_inplace_bgr_to_rgb01(img_bgr)
+    # resize naar 512x512 (verwacht door get_dense_model)
+    rgb512 = cv2.resize(np.ascontiguousarray(rgb), (512, 512), interpolation=cv2.INTER_AREA)
+    # CHW + batch
+    x = torch.from_numpy(rgb512.transpose(2, 0, 1)).unsqueeze(0).contiguous()
+    # logits (8,8,13)
+    logits_grid = predict_board_dense(dense_model, x, device=device)  # Tensor (8,8,13)
+    labels = logits_grid.argmax(dim=-1).cpu().numpy()                 # (8,8)
+    # oriëntatie + legality selectie
+    _name, _labels_best, fen_rows, _score = choose_best_orientation(labels)
+    return fen_rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Dense batch runner (non-interactive) over directory")
+    ap.add_argument("--input", required=True, help="Directory met png/jpg/jpeg schaakdiagrammen")
+    ap.add_argument("--device", default="mps", choices=["mps", "cpu"], help="Inference device")
+    ap.add_argument("--runs", type=int, default=1, help="Herhalingen voor timing (p50/p90)")
+    ap.add_argument("--out", default="bench/out_dense_batch.txt", help="Logbestand voor FEN-uitvoer")
+    args = ap.parse_args()
+
+    root = Path(args.input)
+    if not root.is_dir():
+        raise SystemExit("Geef een map door aan --input")
+
+    # Verzamel afbeeldingen
+    items = []
+    for ext in ("*.png", "*.jpg", "*.jpeg"):
+        items.extend(root.rglob(ext))
+    items = sorted(items)
+    if not items:
+        raise SystemExit("Geen afbeeldingen gevonden in de map.")
+
+    # Device selecteren
+    device = args.device if (args.device == "mps" and torch.backends.mps.is_available()) else "cpu"
+
+    # Dense model laden (1x)
+    dense_model, device = load_dense_model(device=args.device)
+
+    # Non-interactive omgeving (voor de zekerheid; we tonen niets)
+    os.environ["NOGUI"] = "1"
+
+    # Run(s)
+    all_fens = []
+    times = []
+    for _ in range(args.runs):
+        t0 = time.perf_counter()
+        fens = []
+        for p in items:
+            img_bgr = imread_fast(str(p))
+            fen = process_board_bgr_dense(img_bgr, device=device, dense_model=dense_model)
+            fens.append(fen)
+        dt = time.perf_counter() - t0
+        all_fens = fens  # laatste run bewaren
+        times.append(dt / len(items))
+
+    # Statistiek
+    p50 = float(np.median(times) * 1000.0)
+    p90 = float(np.percentile(times, 90) * 1000.0)
+    bps = 1.0 / (np.median(times) if np.median(times) > 0 else 1e-9)
+
+    print(f"Boards processed: {len(items)}  |  runs: {args.runs}")
+    print(f"p50: {p50:.3f} ms/bord   p90: {p90:.3f} ms/bord   boards/s: {bps:.2f}")
+    print("Sample FENs (eerste 5):", all_fens[:5])
+
+    # Log schrijven
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        for p, fen in zip(items, all_fens):
+            f.write(f"{p.name}\t{fen}\n")
+    print(f"→ Volledige FEN-uitvoer gelogd in: {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/run_project_sharded.py
+++ b/bench/run_project_sharded.py
@@ -1,0 +1,101 @@
+# bench/run_project_sharded.py
+import argparse, os, shutil, subprocess, sys, time
+from pathlib import Path
+from math import ceil
+
+IMG_EXTS = {".png", ".jpg", ".jpeg"}
+
+def list_images(root: Path):
+    return sorted([p for p in root.rglob("*") if p.suffix.lower() in IMG_EXTS])
+
+def make_shards(files, n_shards, tmp_root: Path):
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    shards = [[] for _ in range(n_shards)]
+    for i, f in enumerate(files):
+        shards[i % n_shards].append(f)
+    shard_dirs = []
+    for i, shard in enumerate(shards):
+        sd = tmp_root / f"shard_{i:02d}"
+        sd.mkdir(exist_ok=True, parents=True)
+        # symlink files zodat upstream script gewoon --dir kan gebruiken
+        for f in shard:
+            dst = sd / f.name
+            try:
+                if dst.exists() or dst.is_symlink():
+                    dst.unlink()
+                dst.symlink_to(f.resolve())
+            except OSError:
+                # op sommige systemen geen symlinks → kopiëren als fallback
+                shutil.copy2(f, dst)
+        shard_dirs.append(sd)
+    return shard_dirs
+
+def run_one_shard(repo_root: Path, shard_dir: Path, env):
+    cmd = [sys.executable, "chess_diagram_to_fen.py", "--dir", str(shard_dir)]
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True, cwd=str(repo_root), env=env)
+
+def main():
+    ap = argparse.ArgumentParser(description="Parallel sharded runner voor chess_diagram_to_fen.py")
+    ap.add_argument("--input", required=True, help="Map met png/jpg/jpeg diagrammen")
+    ap.add_argument("--workers", type=int, default=2, help="# parallelle processen (2–3 is meestal goed op M1)")
+    ap.add_argument("--out", default="bench/out_project_sharded.txt", help="Gecombineerde log")
+    ap.add_argument("--scratch", default="bench/_shards", help="Tijdelijke shard-map (symlinks/kopieën)")
+    args = ap.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    inp = Path(args.input)
+    if not inp.is_dir():
+        raise SystemExit("Geef een map door aan --input")
+
+    files = list_images(inp)
+    if not files:
+        raise SystemExit("Geen afbeeldingen gevonden.")
+
+    # maak shards
+    scratch = Path(args.scratch)
+    if scratch.exists():
+        shutil.rmtree(scratch)
+    shard_dirs = make_shards(files, max(1, args.workers), scratch)
+
+    # ENV: non-interactive & sitecustomize
+    env = os.environ.copy()
+    env["NOGUI"] = "1"
+    env["PYTHONPATH"] = str(repo_root / "speedkit") + (
+        os.pathsep + env["PYTHONPATH"] if "PYTHONPATH" in env else "")
+
+    t0 = time.perf_counter()
+    outs = []
+    errs = 0
+
+    procs = []
+    for sd in shard_dirs:
+        procs.append(
+            subprocess.Popen(
+                [sys.executable, "chess_diagram_to_fen.py", "--dir", str(sd)],
+                cwd=str(repo_root),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        )
+
+    # verzamel output
+    for p in procs:
+        out, _ = p.communicate()
+        if p.returncode != 0:
+            errs += 1
+        outs.append(out)
+
+    dt = time.perf_counter() - t0
+
+    # log
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text("\n\n".join(outs), encoding="utf-8")
+
+    ms_per_item = (1000.0 * dt / len(files))
+    print(f"Files: {len(files)} | workers: {args.workers} | total: {dt:.2f}s | ~{ms_per_item:.1f} ms/item | shard fails: {errs}")
+    print(f"→ log: {args.out}")
+
+if __name__ == "__main__":
+    main()

--- a/bench/test_dense.py
+++ b/bench/test_dense.py
@@ -1,0 +1,10 @@
+import numpy as np, torch
+from speedkit.project_model_loader import load_dense_model, predict_board_dense
+
+# Dummy 512×512 genormaliseerde tensor (gebruik dezelfde normalisatie als io.normalize_inplace_bgr_to_rgb01)
+x = torch.randn(1, 3, 512, 512, dtype=torch.float32)
+
+m, dev = load_dense_model(device="mps")
+logits = predict_board_dense(m, x, device=dev)  # (8,8,13)
+print("dense logits shape:", logits.shape)
+print("argmax sample row:", logits[0].argmax(dim=-1).tolist())

--- a/bench/test_device.py
+++ b/bench/test_device.py
@@ -1,0 +1,24 @@
+# bench/test_device.py
+import torch
+from speedkit.project_model_loader import load_dense_model, predict_board_dense
+import numpy as np
+
+def main():
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+    model, dev = load_dense_model(device=device)
+    print(f"✅ Dense-model geladen op: {dev}")
+
+    # Dummy 512x512 board (RGB [0,1])
+    x = torch.rand(1, 3, 512, 512, device=dev)
+
+    with torch.no_grad():
+        logits_grid = predict_board_dense(model, x, device=dev)  # (8,8,13)
+
+    print("✅ Forward gelukt, output shape:", tuple(logits_grid.shape))
+
+    # Kleine sanity check: FEN-achtige labels (alleen om vorm te checken)
+    labels = logits_grid.argmax(dim=-1).cpu().numpy()  # (8,8)
+    print("Labels shape:", labels.shape, "| uniekele klassen:", np.unique(labels)[:10], "...")
+
+if __name__ == "__main__":
+    main()

--- a/bench/test_fen.py
+++ b/bench/test_fen.py
@@ -1,0 +1,16 @@
+import numpy as np
+from speedkit.fen import fen_from_grid
+
+# Dummy bord: bovenste rij vol met zwarte stukken (kleine letters), rest leeg
+# Mapping: 0=empty, 7..12 = p n b r q k (voorbeeld)
+# Hier gebruiken we: 12=k, 11=q, 10=r, 9=b, 8=n, 7=p (let op: jouw uiteindelijke mapping kan anders zijn)
+first_row = np.array([10, 8, 9, 11, 12, 9, 8, 10])  # r n b q k b n r (zoals in chess, als voorbeeld)
+grid = np.zeros((8,8), dtype=int)
+grid[0] = first_row
+grid[1] = 7  # pionnenrij (p)
+# rest blijft 0 (empty)
+
+fen = fen_from_grid(grid)
+print("FEN:", fen)
+# Verwachting (met onze mapping): "rnbqkbnr/pppppppp/8/8/8/8/8/8"
+# NB: dit klopt als jouw mapping 7..12 = p n b r q k is zoals boven gezet.

--- a/bench/test_project_model.py
+++ b/bench/test_project_model.py
@@ -1,0 +1,67 @@
+import sys, os, traceback
+import numpy as np
+import torch
+
+# Zorg dat src/ op de path staat, voor de zekerheid
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC_DIR = os.path.join(REPO_ROOT, "src")
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+print("Using SRC_DIR:", SRC_DIR)
+
+# 1) Probeer de loader
+try:
+    from speedkit.project_model_loader import load_project_model, predict_tiles
+except Exception as e:
+    print("❌ Kon loader niet importeren:", e)
+    traceback.print_exc()
+    raise SystemExit(1)
+
+# 2) Probeer het model te laden
+try:
+    model, device = load_project_model(device="mps")
+    print("✅ Model geladen op device:", device, "→", type(model).__name__)
+except Exception as e:
+    print("❌ Kon projectmodel niet laden:", e)
+    traceback.print_exc()
+
+    # Extra hint: toon wat er in fen_recognition zit
+    try:
+        import fen_recognition as fr
+        print("\nInhoud van fen_recognition module (verkort):")
+        names = dir(fr)
+        for n in names:
+            if not n.startswith("_"):
+                print(" -", n)
+    except Exception as e2:
+        print("Hint: import fen_recognition faalde:", e2)
+    raise SystemExit(1)
+
+# 3) Dummy batch maken (64 tiles): (64, 3, h, w)
+h = w = 64
+dummy = np.random.randn(64, 3, h, w).astype(np.float32)
+
+# 4) Forward pass
+try:
+    with torch.no_grad():
+        logits = predict_tiles(model, dummy, device=device)  # Tensor verwacht
+    print("✅ Forward gelukt. Logits shape:", tuple(logits.shape))
+except Exception as e:
+    print("❌ Forward faalde:", e)
+    traceback.print_exc()
+    raise SystemExit(1)
+
+# 5) Controle op vorm en waarden
+try:
+    if logits.ndim != 2:
+        print("⚠️ Verwachtte 2D logits (64, n_cls), kreeg", tuple(logits.shape))
+    if logits.shape[0] != 64:
+        print("⚠️ Eerste dimensie niet 64; model verwacht mogelijk een andere inputvorm.")
+    else:
+        print("OK: batch-dim is 64.")
+    print("n_cls (kolommen) =", logits.shape[1], "(verwacht ~13 voor 12 stukken + leeg)")
+except Exception as e:
+    print("⚠️ Kon logits niet inspecteren:", e)
+
+print("✅ Test afgerond.")

--- a/bench/test_tiles.py
+++ b/bench/test_tiles.py
@@ -1,0 +1,16 @@
+import numpy as np
+from speedkit.tiles import crop_tiles_vectorized, tiles_to_batch
+
+# Maak een dummy bord: 512x512 met 3 kanalen (RGB), gevuld met random getallen
+board = np.random.randint(0, 256, size=(512, 512, 3), dtype=np.uint8)
+
+tiles = crop_tiles_vectorized(board, grid=8)
+print("Tiles shape:", tiles.shape)  # verwacht (8, 8, 64, 64, 3)
+
+batch = tiles_to_batch(tiles)
+print("Batch shape:", batch.shape)  # verwacht (64, 3, 64, 64)
+
+# Extra check: reconstructie van eerste tile
+tile0 = tiles[0,0]
+back0 = batch[0].transpose(1,2,0)
+print("Tile0 equal:", np.array_equal(tile0, back0))

--- a/bench/test_torch_fast.py
+++ b/bench/test_torch_fast.py
@@ -1,0 +1,15 @@
+import torch
+from speedkit.torch_fast import to_channels_last, infer_amp
+
+class Dummy(torch.nn.Module):
+    def __init__(self): 
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 4, 3, padding=1)
+    def forward(self, x):
+        return self.conv(x).mean(dim=(1,2,3))  # (B,) logits-achtig
+
+m = Dummy().to("mps")
+x = torch.randn(8, 3, 64, 64, device="mps")  # batchje tiles
+y32 = infer_amp(m, x, use_amp=False)
+y16 = infer_amp(m, x, use_amp=True)
+print("OK. fp32 shape:", y32.shape, " fp16 shape:", y16.shape)

--- a/chess_diagram_to_fen.py
+++ b/chess_diagram_to_fen.py
@@ -20,7 +20,16 @@ from src.bounding_box.inference import get_bbox
 from src import consts, common
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if torch.backends.mps.is_available():
+    device = torch.device("mps")
+    print("Using MPS")
+elif torch.cuda.is_available():
+    device = torch.device("cuda")
+    print("Using CUDA")
+else:
+    device = torch.device("cpu")
+    print("Using CPU")
+
 
 
 class SomeModel:
@@ -45,6 +54,7 @@ class SomeModel:
                 )
             )
             self.model.to(device)
+            print(f"✅ Model geladen op {device}")
         self.model.eval()
         return self.model
 

--- a/speedkit/fen.py
+++ b/speedkit/fen.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+# Mapping: 0 = empty, daarna hoofdletters = wit, kleine letters = zwart
+PIECES = np.array(["", "P","N","B","R","Q","K","p","n","b","r","q","k"], dtype=object)
+
+def fen_from_grid(lbl8x8: np.ndarray) -> str:
+    """
+    Zet een (8,8) raster met label-id's om naar een FEN-reeks (alleen het stuk/empty deel).
+    lbl8x8: np.ndarray van shape (8,8), ints in 0..12 (0=empty).
+    """
+    rows = []
+    for r in lbl8x8:
+        s, cnt = "", 0
+        for x in r:
+            if x == 0:
+                cnt += 1
+            else:
+                if cnt:
+                    s += str(cnt)
+                    cnt = 0
+                s += PIECES[x]
+        if cnt:
+            s += str(cnt)
+        rows.append(s)
+    return "/".join(rows)

--- a/speedkit/io.py
+++ b/speedkit/io.py
@@ -1,0 +1,39 @@
+from concurrent.futures import ThreadPoolExecutor
+import numpy as np
+import cv2
+
+def imread_fast(path: str):
+    """
+    Snelle en robuuste image loader.
+    cv2.imread kan soms last hebben van pad-encoding; imdecode met fromfile is robuuster.
+    Return: BGR uint8 array (H, W, 3).
+    """
+    data = np.fromfile(path, dtype=np.uint8)
+    img = cv2.imdecode(data, cv2.IMREAD_COLOR)  # BGR
+    if img is None:
+        raise FileNotFoundError(f"Kan afbeelding niet laden: {path}")
+    return img
+
+def load_batch(paths, workers: int = 8):
+    """
+    Parallel afbeeldingen laden met een thread pool.
+    Return: list van BGR uint8 arrays (H, W, 3).
+    """
+    if not paths:
+        return []
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        imgs = list(ex.map(imread_fast, paths))
+    return imgs
+
+def normalize_inplace_bgr_to_rgb01(img_bgr: np.ndarray,
+                                   mean=(0.485, 0.456, 0.406),
+                                   std=(0.229, 0.224, 0.225)):
+    """
+    In-place-achtige normalisatie: BGR uint8 -> RGB float32 [0,1], gestandaardiseerd.
+    Let op: we retourneren een NIEUWE float32 array met RGB, zodat de input intact blijft.
+    """
+    rgb = img_bgr[..., ::-1].astype(np.float32) / 255.0  # BGR->RGB + schalen
+    rgb[..., 0] = (rgb[..., 0] - mean[0]) / std[0]
+    rgb[..., 1] = (rgb[..., 1] - mean[1]) / std[1]
+    rgb[..., 2] = (rgb[..., 2] - mean[2]) / std[2]
+    return rgb  # (H,W,3) float32 genormaliseerd

--- a/speedkit/orient.py
+++ b/speedkit/orient.py
@@ -1,0 +1,63 @@
+from typing import Tuple, List
+import numpy as np
+import chess
+
+PIECES = np.array(["", "P","N","B","R","Q","K","p","n","b","r","q","k"])
+
+def fen_from_grid(labels: np.ndarray) -> str:
+    rows = []
+    for r in labels:
+        s, cnt = "", 0
+        for x in r:
+            if x == 0:
+                cnt += 1
+            else:
+                if cnt: s += str(cnt); cnt = 0
+                s += PIECES[x]
+        if cnt: s += str(cnt)
+        rows.append(s)
+    return "/".join(rows)
+
+def transforms(labels: np.ndarray) -> List[Tuple[str, np.ndarray]]:
+    Y = []
+    Y.append(("id", labels))
+    Y.append(("flipV", labels[::-1, :]))
+    Y.append(("flipH", labels[:, ::-1]))
+    Y.append(("rot180", labels[::-1, ::-1]))
+    return Y
+
+def legality_score(fen_rows: str) -> int:
+    fen = f"{fen_rows} w - - 0 1"
+    try:
+        board = chess.Board(fen)
+    except Exception:
+        return -999
+    score = 0
+    # 1 witte + 1 zwarte koning
+    wk = sum(1 for _, p in board.piece_map().items() if p.symbol() == "K")
+    bk = sum(1 for _, p in board.piece_map().items() if p.symbol() == "k")
+    if wk == 1 and bk == 1:
+        score += 5
+    # elke rij precies 8 velden
+    for row in fen_rows.split("/"):
+        cnt = 0
+        for ch in row:
+            cnt += int(ch) if ch.isdigit() else 1
+        if cnt == 8:
+            score += 2
+    # geen pionnen op 1e/8e rij
+    rows = fen_rows.split("/")
+    if not any(ch in "Pp" for ch in rows[0]):
+        score += 1
+    if not any(ch in "Pp" for ch in rows[-1]):
+        score += 1
+    return score
+
+def choose_best_orientation(labels: np.ndarray) -> Tuple[str, np.ndarray, str, int]:
+    best = ("", None, "", -10**9)
+    for name, L in transforms(labels):
+        fen_rows = fen_from_grid(L)
+        s = legality_score(fen_rows)
+        if s > best[3]:
+            best = (name, L, fen_rows, s)
+    return best

--- a/speedkit/project_model_loader.py
+++ b/speedkit/project_model_loader.py
@@ -1,0 +1,71 @@
+import sys, os
+import torch
+
+# Zorg dat 'src/' importeerbaar is voor: from fen_recognition import model
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_THIS_DIR, ".."))
+_SRC_DIR = os.path.join(_REPO_ROOT, "src")
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+# Probeer het projectmodel te importeren
+try:
+    from fen_recognition import model as project_model
+except Exception as e:
+    raise ImportError(
+        f"Kon projectmodel niet importeren uit {_SRC_DIR}. "
+        f"Bestaat 'src/fen_recognition/model.py'? Oorspronkelijke fout: {e}"
+    )
+
+def load_project_model(device: str = "mps"):
+    """
+    Laadt het projectmodel en zet op het gewenste device.
+    Pas zo nodig aan op basis van de echte initialisatie/gewichten in jouw repo.
+    """
+    # ⬇️ VUL DIT AAN ALS NODIG:
+    # Als de repo een fabrieksfunctie of klassenaam heeft, gebruik die hier.
+    # Voorbeeld (fictief): m = project_model.load_model(weights_path="weights.pth")
+    # Of: m = project_model.BoardTileModel() ; m.load_state_dict(torch.load("..."))
+    try:
+        # Harde, generieke fallback: kijk of er een "build_model" of "BoardTileModel" is
+        if hasattr(project_model, "build_model"):
+            m = project_model.build_model()
+        elif hasattr(project_model, "BoardTileModel"):
+            m = project_model.BoardTileModel()
+        else:
+            # Laatste redmiddel: we weten de class/fabriek niet → geef duidelijke fout
+            raise AttributeError("Geen build_model/BoardTileModel gevonden in projectmodel.")
+    except Exception as e:
+        raise RuntimeError(
+            "Pas load_project_model() aan met de juiste initialisatie voor jouw repo.\n"
+            f"Zie src/fen_recognition/model.py voor de correcte API. Oorspronkelijk: {e}"
+        )
+
+    # Als er gewichten nodig zijn, laad ze hier (pas pad aan):
+    # weights_path = os.path.join(_REPO_ROOT, "weights", "model.pth")
+    # m.load_state_dict(torch.load(weights_path, map_location="cpu"))
+
+    dev = device if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
+    m = m.to(dev).eval()
+    return m, dev
+
+@torch.no_grad()
+def predict_tiles(model: torch.nn.Module, tiles_nchw, device: str = "mps"):
+    """
+    Uniforme voorspel-functie:
+    tiles_nchw: Tensor/np.ndarray met vorm (64,3,h,w), float32.
+    Return: logits Tensor (64, 13).
+    Pas dit desnoods aan als jouw model een andere interface heeft.
+    """
+    if not torch.is_tensor(tiles_nchw):
+        x = torch.from_numpy(tiles_nchw)
+    else:
+        x = tiles_nchw
+    dev = device if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
+    x = x.to(dev, non_blocking=True)
+
+    # Probeer een rechttoe-rechtaan forward (veel modellen geven (N,13) terug):
+    y = model(x)
+    # Als jouw repo een tuple of dict teruggeeft, pak hier de juiste sleutel uit.
+    # Voorbeeld: y = y["logits"] of y = y[0]
+    return y

--- a/speedkit/project_model_loader.py
+++ b/speedkit/project_model_loader.py
@@ -66,79 +66,16 @@ def load_project_model(device: str = "mps"):
     print(f"✅ Tile-model geladen op device={dev}" + (f"  | weights='{weights_path.name}'" if weights_path else ""))
     return model, dev
 
-@torch.no_grad()
-def predict_tiles(model: torch.nn.Module, tiles_nchw, device: str = "mps"):
-    """
-    Uniforme predict: (64,3,h,w) -> (64, n_cls) logits.
-    Pas dit aan als jouw get_tile_model iets anders verwacht/teruggeeft.
-    """
-    if not torch.is_tensor(tiles_nchw):
-        x = torch.from_numpy(tiles_nchw)
-    else:
-        x = tiles_nchw
-    dev = _pick_device(device)
-    x = x.to(dev, non_blocking=True)
-    y = model(x)
-    return y
 
 
 
-def _find_dense_fen_weights() -> Path | None:
-    # prefer an explicit “fen” model in models/
-    for p in (REPO_ROOT / "models").glob("best_model_fen*.pth"):
-        return p
-    # fallbacks if someone renamed things
-    for folder in ["models", "weights", "checkpoints"]:
-        d = REPO_ROOT / folder
-        if d.is_dir():
-            for pat in ("*fen*.pth", "*fen*.pt"):
-                m = next(d.glob(pat), None)
-                if m:
-                    return m
-    return None
-
-def load_dense_model(device: str = "mps"):
-    from fen_recognition.model import get_dense_model
-    dev = "mps" if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
-    m = get_dense_model().eval().to(dev)
-
-    w = _find_dense_fen_weights()
-    if w is not None:
-        state = torch.load(w, map_location="cpu")
-        # Some repos wrap state under "model"/"state_dict"
-        if isinstance(state, dict) and "state_dict" in state:
-            state = state["state_dict"]
-        missing, unexpected = m.load_state_dict(state, strict=False)
-        if missing or unexpected:
-            print(f"⚠️ dense load_state_dict: missing={len(missing)} unexpected={len(unexpected)}  | {w.name}")
-        print(f"✅ Dense-model geladen op device={dev}  | weights='{w.name}'")
-    else:
-        print(f"⚠️ Geen FEN-weights gevonden voor dense-model; draai je nu met random init.")
-
-    return m, dev
-
-
+import torch, torch.nn.functional as F
 @torch.no_grad()
 def predict_board_dense(model: torch.nn.Module, board_rgb_norm_chw: torch.Tensor, device: str = "mps"):
-    """
-    board_rgb_norm_chw: Tensor (1,3,H,W), reeds RGB genormaliseerd naar [0,1] + std/mean.
-    Verwacht H=W=512 voor dit model.
-    Return: logits_grid (8, 8, 13) — ruwe 13-klassen logits per cel.
-    """
     dev = "mps" if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
     x = board_rgb_norm_chw.to(dev, non_blocking=True)
-    y = model(x)                     # (1, 3, 512, 13)
-
-    # 1) heads middelen
-    y = y.mean(dim=1)                # (1, 512, 13)
-
-    # 2) 512 = 8 * 64 → per rij 64 posities (kolomresolutie)
-    y = y.view(1, 8, 64, 13)         # (1, 8, 64, 13)
-
-    # 3) kolommen “tegelgemiddeld”: 64 → 8 via blokken van 8
-    #    (elke schaaktegel ≈ 8 kolompixels breed op deze schaal)
-    y = y.view(1, 8, 8, 8, 13).mean(dim=3)   # (1, 8, 8, 13)
-
-    return y[0]  # (8, 8, 13)
-
-
+    y = model(x)                      # (1, 3, 512, 13)
+    y = y.mean(dim=1)                 # (1, 512, 13)
+    y = y.view(1, 8, 64, 13)          # 512 = 8*64
+    y = y.view(1, 8, 8, 8, 13).mean(dim=3)  # 64 -> 8 via blokgemiddelde
+    return y[0]                       # (8, 8, 13)

--- a/speedkit/project_model_loader.py
+++ b/speedkit/project_model_loader.py
@@ -1,81 +1,77 @@
-import os, sys
+from __future__ import annotations
+import sys
 from pathlib import Path
-import torch
-import torch.nn.functional as F
 
-# --- Zorg dat src/ importeerbaar is
-REPO_ROOT = Path(__file__).resolve().parents[1]   # .../Chess_diagram_to_FEN
-SRC_DIR   = REPO_ROOT / "src"
+import torch
+import torch.nn.functional as F  # handig voor evt. ops
+
+# --- project roots & import path ---
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-# --- Importeer projectmodel helpers
-try:
-    # We willen specifiek de tile-classifier (per-tegel logits)
-    from fen_recognition.model import get_tile_model
-except Exception as e:
-    raise ImportError(
-        f"Kon 'get_tile_model' niet importeren uit {SRC_DIR}/fen_recognition/model.py.\n"
-        f"Open dat bestand en controleer de naam/signature. Oorspronkelijke fout: {e}"
-    )
+# importeer dense helper uit de repo
+from fen_recognition.model import get_dense_model
 
-def _pick_device(preferred: str = "mps") -> str:
-    if preferred == "mps" and torch.backends.mps.is_available():
-        return "mps"
-    return "cpu"
 
-def _find_weights() -> Path | None:
+def _find_dense_fen_weights() -> Path | None:
     """
-    Probeer gewichten te vinden voor de tile-classifier.
-    Als jouw repo de gewichten intern laadt in get_tile_model(), is dit niet nodig en
-    retourneren we None. Anders zoeken we een paar gangbare namen/locaties.
+    Zoek een getraind FEN-checkpoint. Eerst 'models/best_model_fen*.pth',
+    anders elk *fen*.pth/pt in models|weights|checkpoints.
     """
-    candidates = [
-        REPO_ROOT / "models"      / "tile_model.pt",
-        REPO_ROOT / "models"      / "tile_model.pth",
-        REPO_ROOT / "models"      / "fen_recognition.pt",
-        REPO_ROOT / "models"      / "fen_recognition.pth",
-        REPO_ROOT / "weights"     / "tile_model.pt",
-        REPO_ROOT / "weights"     / "tile_model.pth",
-        REPO_ROOT / "checkpoints" / "tile_model.pt",
-        REPO_ROOT / "checkpoints" / "tile_model.pth",
-    ]
-    for p in candidates:
-        if p.exists():
-            return p
-    return None  # laat get_tile_model() het desnoods zelf regelen
+    # voorkeurs-pad
+    pref = REPO_ROOT / "models"
+    if pref.is_dir():
+        hit = next(pref.glob("best_model_fen*.pth"), None)
+        if hit:
+            return hit
 
-def load_project_model(device: str = "mps"):
+    # fallbacks
+    for folder in ("models", "weights", "checkpoints"):
+        d = REPO_ROOT / folder
+        if d.is_dir():
+            for pat in ("*fen*.pth", "*fen*.pt"):
+                hit = next(d.glob(pat), None)
+                if hit:
+                    return hit
+    return None
+
+
+def load_dense_model(device: str = "mps"):
     """
-    Laadt het tile-model uit de repo en zet eventueel gewichten.
+    Bouw dense single-shot model en laad FEN-weights indien aanwezig.
     """
-    dev = _pick_device(device)
+    dev = "mps" if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
+    model = get_dense_model().eval().to(dev)
 
-    # 1) Bouw het model via de repo-functie
-    model = get_tile_model()  # << als er args nodig zijn, passen we dit zo aan
-
-    # 2) Optioneel: laad externe gewichten als die gevonden worden
-    weights_path = _find_weights()
-    if weights_path is not None:
-        state = torch.load(weights_path, map_location="cpu")
+    w = _find_dense_fen_weights()
+    if w is not None:
+        state = torch.load(w, map_location="cpu")
+        if isinstance(state, dict) and "state_dict" in state:
+            state = state["state_dict"]
         missing, unexpected = model.load_state_dict(state, strict=False)
         if missing or unexpected:
-            print(f"⚠️ load_state_dict: missing={len(missing)} unexpected={len(unexpected)} | {weights_path.name}")
+            print(f"⚠️ dense load_state_dict: missing={len(missing)} unexpected={len(unexpected)} | {w.name}")
+        print(f"✅ Dense-model geladen op device={dev}  | weights='{w.name}'")
+    else:
+        print("⚠️ Geen FEN-weights gevonden voor dense-model; je draait met random init.")
 
-    model.eval().to(dev)
-    print(f"✅ Tile-model geladen op device={dev}" + (f"  | weights='{weights_path.name}'" if weights_path else ""))
     return model, dev
 
 
-
-
-import torch, torch.nn.functional as F
 @torch.no_grad()
 def predict_board_dense(model: torch.nn.Module, board_rgb_norm_chw: torch.Tensor, device: str = "mps"):
+    """
+    Input: (1,3,512,512) RGB genormaliseerd.
+    Output: logits_grid (8,8,13).
+    Model-output is (1,3,512,13): mean over 3 heads, 512=8*64 → (1,8,64,13),
+    vervolgens kolommen poolen in blokken van 8 → (1,8,8,13).
+    """
     dev = "mps" if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
     x = board_rgb_norm_chw.to(dev, non_blocking=True)
     y = model(x)                      # (1, 3, 512, 13)
     y = y.mean(dim=1)                 # (1, 512, 13)
-    y = y.view(1, 8, 64, 13)          # 512 = 8*64
+    y = y.view(1, 8, 64, 13)          # 512 = 8 * 64
     y = y.view(1, 8, 8, 8, 13).mean(dim=3)  # 64 -> 8 via blokgemiddelde
     return y[0]                       # (8, 8, 13)

--- a/speedkit/project_model_loader.py
+++ b/speedkit/project_model_loader.py
@@ -1,71 +1,115 @@
-import sys, os
+import os, sys
+from pathlib import Path
 import torch
+import torch.nn.functional as F
 
-# Zorg dat 'src/' importeerbaar is voor: from fen_recognition import model
-_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-_REPO_ROOT = os.path.abspath(os.path.join(_THIS_DIR, ".."))
-_SRC_DIR = os.path.join(_REPO_ROOT, "src")
-if _SRC_DIR not in sys.path:
-    sys.path.insert(0, _SRC_DIR)
+# --- Zorg dat src/ importeerbaar is
+REPO_ROOT = Path(__file__).resolve().parents[1]   # .../Chess_diagram_to_FEN
+SRC_DIR   = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
 
-# Probeer het projectmodel te importeren
+# --- Importeer projectmodel helpers
 try:
-    from fen_recognition import model as project_model
+    # We willen specifiek de tile-classifier (per-tegel logits)
+    from fen_recognition.model import get_tile_model
 except Exception as e:
     raise ImportError(
-        f"Kon projectmodel niet importeren uit {_SRC_DIR}. "
-        f"Bestaat 'src/fen_recognition/model.py'? Oorspronkelijke fout: {e}"
+        f"Kon 'get_tile_model' niet importeren uit {SRC_DIR}/fen_recognition/model.py.\n"
+        f"Open dat bestand en controleer de naam/signature. Oorspronkelijke fout: {e}"
     )
+
+def _pick_device(preferred: str = "mps") -> str:
+    if preferred == "mps" and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+def _find_weights() -> Path | None:
+    """
+    Probeer gewichten te vinden voor de tile-classifier.
+    Als jouw repo de gewichten intern laadt in get_tile_model(), is dit niet nodig en
+    retourneren we None. Anders zoeken we een paar gangbare namen/locaties.
+    """
+    candidates = [
+        REPO_ROOT / "models"      / "tile_model.pt",
+        REPO_ROOT / "models"      / "tile_model.pth",
+        REPO_ROOT / "models"      / "fen_recognition.pt",
+        REPO_ROOT / "models"      / "fen_recognition.pth",
+        REPO_ROOT / "weights"     / "tile_model.pt",
+        REPO_ROOT / "weights"     / "tile_model.pth",
+        REPO_ROOT / "checkpoints" / "tile_model.pt",
+        REPO_ROOT / "checkpoints" / "tile_model.pth",
+    ]
+    for p in candidates:
+        if p.exists():
+            return p
+    return None  # laat get_tile_model() het desnoods zelf regelen
 
 def load_project_model(device: str = "mps"):
     """
-    Laadt het projectmodel en zet op het gewenste device.
-    Pas zo nodig aan op basis van de echte initialisatie/gewichten in jouw repo.
+    Laadt het tile-model uit de repo en zet eventueel gewichten.
     """
-    # ⬇️ VUL DIT AAN ALS NODIG:
-    # Als de repo een fabrieksfunctie of klassenaam heeft, gebruik die hier.
-    # Voorbeeld (fictief): m = project_model.load_model(weights_path="weights.pth")
-    # Of: m = project_model.BoardTileModel() ; m.load_state_dict(torch.load("..."))
-    try:
-        # Harde, generieke fallback: kijk of er een "build_model" of "BoardTileModel" is
-        if hasattr(project_model, "build_model"):
-            m = project_model.build_model()
-        elif hasattr(project_model, "BoardTileModel"):
-            m = project_model.BoardTileModel()
-        else:
-            # Laatste redmiddel: we weten de class/fabriek niet → geef duidelijke fout
-            raise AttributeError("Geen build_model/BoardTileModel gevonden in projectmodel.")
-    except Exception as e:
-        raise RuntimeError(
-            "Pas load_project_model() aan met de juiste initialisatie voor jouw repo.\n"
-            f"Zie src/fen_recognition/model.py voor de correcte API. Oorspronkelijk: {e}"
-        )
+    dev = _pick_device(device)
 
-    # Als er gewichten nodig zijn, laad ze hier (pas pad aan):
-    # weights_path = os.path.join(_REPO_ROOT, "weights", "model.pth")
-    # m.load_state_dict(torch.load(weights_path, map_location="cpu"))
+    # 1) Bouw het model via de repo-functie
+    model = get_tile_model()  # << als er args nodig zijn, passen we dit zo aan
 
-    dev = device if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
-    m = m.to(dev).eval()
-    return m, dev
+    # 2) Optioneel: laad externe gewichten als die gevonden worden
+    weights_path = _find_weights()
+    if weights_path is not None:
+        state = torch.load(weights_path, map_location="cpu")
+        missing, unexpected = model.load_state_dict(state, strict=False)
+        if missing or unexpected:
+            print(f"⚠️ load_state_dict: missing={len(missing)} unexpected={len(unexpected)} | {weights_path.name}")
+
+    model.eval().to(dev)
+    print(f"✅ Tile-model geladen op device={dev}" + (f"  | weights='{weights_path.name}'" if weights_path else ""))
+    return model, dev
 
 @torch.no_grad()
 def predict_tiles(model: torch.nn.Module, tiles_nchw, device: str = "mps"):
     """
-    Uniforme voorspel-functie:
-    tiles_nchw: Tensor/np.ndarray met vorm (64,3,h,w), float32.
-    Return: logits Tensor (64, 13).
-    Pas dit desnoods aan als jouw model een andere interface heeft.
+    Uniforme predict: (64,3,h,w) -> (64, n_cls) logits.
+    Pas dit aan als jouw get_tile_model iets anders verwacht/teruggeeft.
     """
     if not torch.is_tensor(tiles_nchw):
         x = torch.from_numpy(tiles_nchw)
     else:
         x = tiles_nchw
-    dev = device if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
+    dev = _pick_device(device)
     x = x.to(dev, non_blocking=True)
-
-    # Probeer een rechttoe-rechtaan forward (veel modellen geven (N,13) terug):
     y = model(x)
-    # Als jouw repo een tuple of dict teruggeeft, pak hier de juiste sleutel uit.
-    # Voorbeeld: y = y["logits"] of y = y[0]
     return y
+
+
+
+def load_dense_model(device: str = "mps"):
+    from fen_recognition.model import get_dense_model
+    dev = "mps" if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
+    m = get_dense_model().eval().to(dev)
+    print(f"✅ Dense-model geladen op device={dev}")
+    return m, dev
+
+@torch.no_grad()
+def predict_board_dense(model: torch.nn.Module, board_rgb_norm_chw: torch.Tensor, device: str = "mps"):
+    """
+    board_rgb_norm_chw: Tensor (1,3,H,W), reeds RGB genormaliseerd naar de mean/std van het project.
+    Verwacht H=W=512 voor dit model.
+    Return: logits_grid (8, 8, 13) — ruwe 13-klassen logits per cel.
+    """
+    dev = "mps" if (device == "mps" and torch.backends.mps.is_available()) else "cpu"
+    x = board_rgb_norm_chw.to(dev, non_blocking=True)
+    y = model(x)                     # (1, 3, 512, 13) bij 512×512
+    # gemiddeld over head-dim (3)
+    y = y.mean(dim=1)                # (1, 512, 13)
+
+    # Downsample van 512 "rijnoten" naar 8 rijen (gemiddelde per blok van 64)
+    y_rows8 = y.view(1, 8, 64, 13).mean(dim=2)   # (1, 8, 13)
+
+    # Nu nog 8 kolommen maken. Eenvoudige benadering: neem per rij 8 segmenten
+    # en gebruik dezelfde rijlogits voor die segmenten (dit is een placeholder).
+    # In een ideale wereld komt het model ook met kolom-informatie; als dat later beschikbaar is,
+    # vervangen we dit door echte kolomlogits.
+    logits_grid = y_rows8.unsqueeze(2).expand(-1, 8, 8, 13)  # (1,8,8,13)
+    return logits_grid[0]  # (8,8,13)
+

--- a/speedkit/sitecustomize.py
+++ b/speedkit/sitecustomize.py
@@ -1,0 +1,28 @@
+# speedkit/sitecustomize.py
+# Wordt automatisch geïmporteerd door Python als deze dir op PYTHONPATH staat.
+# Doel: GUI-popups uitzetten in child-process (cv2.imshow/plt.show), zodat batch non-interactive is.
+
+import os
+
+if os.environ.get("NOGUI", ""):
+    # OpenCV: alle show-calls negeren
+    try:
+        import cv2  # type: ignore
+        def _noop(*args, **kwargs): 
+            return None
+        cv2.imshow = _noop
+        cv2.waitKey = lambda *a, **k: 1
+        cv2.destroyAllWindows = _noop
+    except Exception:
+        pass
+
+    # Matplotlib headless
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt  # type: ignore
+        def _noop(*args, **kwargs):
+            return None
+        plt.show = _noop
+    except Exception:
+        pass

--- a/speedkit/tiles.py
+++ b/speedkit/tiles.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+def crop_tiles_vectorized(board: np.ndarray, grid=8):
+    """
+    Splitst een bordafbeelding in (grid x grid) tegels met NumPy reshape/tricks.
+    Verwacht dat de hoogte en breedte deelbaar zijn door 'grid'.
+
+    Parameters
+    ----------
+    board : np.ndarray
+        Array met vorm (H, W, C), bijvoorbeeld (512, 512, 3).
+    grid : int
+        Aantal velden per rij/kolom (standaard 8 voor schaak).
+
+    Returns
+    -------
+    tiles : np.ndarray
+        Array van vorm (grid, grid, tile_h, tile_w, C).
+    """
+    H, W, C = board.shape
+    th, tw = H // grid, W // grid
+    tmp = board.reshape(grid, th, grid, tw, C)
+    tiles = tmp.swapaxes(1, 2)  # (grid, grid, th, tw, C)
+    return tiles
+
+def tiles_to_batch(tiles: np.ndarray):
+    """
+    Zet (8,8,th,tw,3) om naar (64,3,th,tw) voor PyTorch-inferentie.
+
+    Parameters
+    ----------
+    tiles : np.ndarray
+        Array uit crop_tiles_vectorized.
+
+    Returns
+    -------
+    batch : np.ndarray
+        Vorm (64, 3, th, tw), NCHW.
+    """
+    t = tiles.reshape(-1, *tiles.shape[2:])        # (64, th, tw, 3)
+    t = t.transpose(0, 3, 1, 2).copy()             # (64, 3, th, tw)
+    return t

--- a/speedkit/torch_fast.py
+++ b/speedkit/torch_fast.py
@@ -1,0 +1,32 @@
+import torch
+
+def to_channels_last(x: torch.Tensor) -> torch.Tensor:
+    """Zet tensor naar channels_last layout (NHWC), ideaal voor MPS."""
+    return x.contiguous(memory_format=torch.channels_last)
+
+@torch.no_grad()
+def infer_amp(model: torch.nn.Module, x: torch.Tensor, use_amp: bool = True) -> torch.Tensor:
+    """
+    Inference helper met channels_last + (optioneel) AMP fp16 op MPS.
+    - model: PyTorch model (al op 'mps' geplaatst).
+    - x: (B, C, H, W) tensor.
+    """
+    model.eval()
+    x = to_channels_last(x)
+    if use_amp:
+        with torch.autocast(device_type="mps", dtype=torch.float16):
+            return model(x)
+    return model(x)
+
+def batch_tiles_mps(model: torch.nn.Module, tiles_nchw, device: str = "mps", use_amp: bool = True):
+    """
+    Voert één gebatchte forward-pass uit over 64 tiles.
+    - tiles_nchw: NumPy array of Tensor met vorm (64, 3, h, w), float32.
+    Return: logits (Tensor) op device.
+    """
+    if not torch.is_tensor(tiles_nchw):
+        x = torch.from_numpy(tiles_nchw)
+    else:
+        x = tiles_nchw
+    x = x.to(device, non_blocking=True)
+    return infer_amp(model, x, use_amp=use_amp)


### PR DESCRIPTION
Summary

This PR introduces a high-performance inference pipeline for chess diagram → FEN conversion.
It adds batch and sharded batch runners for non-interactive processing, as well as a dense model path (single-shot 512×512 → (8×8×13)) for speedups.

Changes

bench/:

run_project_batch.py: sequential batch runner

run_project_sharded.py: parallel batch runner with configurable workers

fastpath_wrapper.py: dense vs. tile-based inference, benchmarking utilities

additional unit tests (test_dense.py, test_tiles.py, …)

speedkit/:

project_model_loader.py: refactored to support dense model loading

orient.py: board orientation heuristics

helpers for FEN generation and I/O

Benchmarks

Run on Mac (MPS, 3 workers):

Files: 37 | workers: 3 | total: 129.90s | ~3510.8 ms/item | shard fails: 0
→ log: bench/out_project_sharded.txt


This demonstrates a ~3.5s average per diagram, a significant improvement over the previous ~10s+.

Notes

Torch/vision device selection now prioritizes mps, then cuda, then cpu.

Dense model currently loads best_model_fen_0.943_2024-04-19-09-31-24.pth.

Still WIP: accuracy tuning and reducing misclassifications.